### PR TITLE
Fix: Disable Firebase deployment workflows until service account is c…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -145,29 +145,29 @@ jobs:
           path: build/app/outputs/bundle/release/*.aab
           retention-days: 30
 
-  # Deploy to Firebase Hosting (Web)
-  deploy_web:
-    runs-on: ubuntu-latest
-    needs: [build_web]
-    name: Deploy Web to Firebase
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # Deploy to Firebase Hosting (Web) - DISABLED until Firebase service account is configured
+  # deploy_web:
+  #   runs-on: ubuntu-latest
+  #   needs: [build_web]
+  #   name: Deploy Web to Firebase
+  #   if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Download web build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: web-build
-          path: build/web/
+  #     - name: Download web build artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: web-build
+  #         path: build/web/
 
-      - name: Deploy to Firebase Hosting
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 }}
-          channelId: live
-          projectId: panel-monitor-691c6
+  #     - name: Deploy to Firebase Hosting
+  #       uses: FirebaseExtended/action-hosting-deploy@v0
+  #       with:
+  #         repoToken: ${{ secrets.GITHUB_TOKEN }}
+  #         firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 }}
+  #         channelId: live
+  #         projectId: panel-monitor-691c6
 
   # Create Release
   create_release:

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -1,10 +1,13 @@
-# Flutter Web Deploy to Firebase Hosting on merge
-name: Deploy Flutter Web to Firebase Hosting on merge
+# Flutter Web Deploy to Firebase Hosting on merge - DISABLED
+# Uncomment and configure FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 secret to enable
+name: Deploy Flutter Web to Firebase Hosting on merge (DISABLED)
 
 on:
-  push:
-    branches:
-      - main
+  # Disabled - uncomment when Firebase secret is configured
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch: # Manual trigger only
 
 jobs:
   build_and_deploy:
@@ -28,10 +31,14 @@ jobs:
       - name: Build Flutter web
         run: flutter build web --release --web-renderer html
 
-      - name: Deploy to Firebase Hosting
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 }}
-          channelId: live
-          projectId: panel-monitor-691c6
+      # Disabled until Firebase service account is configured
+      # - name: Deploy to Firebase Hosting
+      #   uses: FirebaseExtended/action-hosting-deploy@v0
+      #   with:
+      #     repoToken: ${{ secrets.GITHUB_TOKEN }}
+      #     firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 }}
+      #     channelId: live
+      #     projectId: panel-monitor-691c6
+
+      - name: Firebase Deployment Disabled
+        run: echo "Firebase deployment is disabled. Configure FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 secret to enable."

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -1,7 +1,11 @@
-# Flutter Web Deploy to Firebase Hosting on PR
-name: Deploy Flutter Web to Firebase Hosting on PR
+# Flutter Web Deploy to Firebase Hosting on PR - DISABLED
+# Uncomment and configure FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 secret to enable
+name: Deploy Flutter Web to Firebase Hosting on PR (DISABLED)
 
-on: pull_request
+on: 
+  # Disabled - uncomment when Firebase secret is configured
+  # pull_request
+  workflow_dispatch: # Manual trigger only
 
 permissions:
   checks: write
@@ -10,7 +14,8 @@ permissions:
 
 jobs:
   build_and_preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    # Disabled until Firebase is configured
+    # if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -31,9 +36,13 @@ jobs:
       - name: Build Flutter web
         run: flutter build web --release --web-renderer html
 
-      - name: Deploy to Firebase Hosting Preview
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 }}
-          projectId: panel-monitor-691c6
+      # Disabled until Firebase service account is configured
+      # - name: Deploy to Firebase Hosting Preview
+      #   uses: FirebaseExtended/action-hosting-deploy@v0
+      #   with:
+      #     repoToken: ${{ secrets.GITHUB_TOKEN }}
+      #     firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 }}
+      #     projectId: panel-monitor-691c6
+
+      - name: Firebase Deployment Disabled
+        run: echo "Firebase deployment is disabled. Configure FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 secret to enable."


### PR DESCRIPTION
…onfigured

- Comment out Firebase deployment steps to prevent secret access errors
- Workflows can be re-enabled once FIREBASE_SERVICE_ACCOUNT_PANEL_MONITOR_691C6 secret is added
- Build and test steps remain active for CI validation